### PR TITLE
INTEGRATED-669

### DIFF
--- a/Command/IndexerRunCommand.php
+++ b/Command/IndexerRunCommand.php
@@ -115,7 +115,10 @@ The <info>%command.name%</info> command starts a indexer run.
                 'php app/console solr:indexer:run -e ' . $input->getOption('env'),
                 $this->getRootDir()
             );
-            $process->run();
+
+            $process->run(function ($type, $buffer) use ($output) {
+                $output->write($buffer, false, $type);
+            });
 
             if (!$process->isSuccessful()) {
                 break; // terminate when there is a error

--- a/DependencyInjection/IntegratedSolrExtension.php
+++ b/DependencyInjection/IntegratedSolrExtension.php
@@ -38,6 +38,7 @@ class IntegratedSolrExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
 
         $loader->load('converter.xml');
+        $loader->load('event.xml');
         $loader->load('indexer.xml');
         $loader->load('queue.xml');
         $loader->load('solarium.xml');

--- a/EventListener/ErrorLogger.php
+++ b/EventListener/ErrorLogger.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+* This file is part of the Integrated package.
+*
+* (c) e-Active B.V. <integrated@e-active.nl>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Integrated\Bundle\SolrBundle\EventListener;
+
+use Psr\Log\LoggerInterface;
+
+use Integrated\Common\Solr\Indexer\Event\ErrorEvent;
+use Integrated\Common\Solr\Indexer\Events;
+use Integrated\Common\Solr\Indexer\Job;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @author Jan Sanne Mulder <jansanne@e-active.nl>
+ */
+class ErrorLogger implements EventSubscriberInterface
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger = null;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::ERROR => 'onError'
+        ];
+    }
+
+    /**
+     * @param ErrorEvent $event
+     */
+    public function onError(ErrorEvent $event)
+    {
+        if (null === $this->logger) {
+            return;
+        }
+
+        $payload = $event->getMessage()->getPayload();
+
+        if ($payload instanceof Job) {
+            $this->logger->error($event->getException()->getMessage(), [
+                'action' => $payload->getAction(),
+                'options' => $payload->getOptions()
+            ]);
+        }
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger = null)
+    {
+        $this->logger = $logger;
+    }
+}

--- a/IntegratedSolrBundle.php
+++ b/IntegratedSolrBundle.php
@@ -15,6 +15,7 @@ use Integrated\Bundle\SolrBundle\DependencyInjection\CompilerPass\RegisterConfig
 use Integrated\Bundle\SolrBundle\DependencyInjection\CompilerPass\RegisterTypePass;
 use Integrated\Bundle\SolrBundle\DependencyInjection\IntegratedSolrExtension;
 
+use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -32,6 +33,7 @@ class IntegratedSolrBundle extends Bundle
 
         $container->addCompilerPass(new RegisterConfigFileProviderPass());
         $container->addCompilerPass(new RegisterTypePass());
+        $container->addCompilerPass(new RegisterListenersPass('integrated_solr.event.dispatcher', 'integrated_solr.event_listener', 'integrated_solr.event_subscriber'));
     }
 
     /**

--- a/Resources/config/event.xml
+++ b/Resources/config/event.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="integrated_solr.event.dispatcher" class="Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher">
+            <argument type="service" id="service_container" />
+        </service>
+
+    </services>
+
+</container>

--- a/Resources/config/indexer.xml
+++ b/Resources/config/indexer.xml
@@ -4,28 +4,25 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <parameters>
-
-		<parameter key="integrated_solr.indexer.mongodb.subscriber.class">Integrated\MongoDB\Solr\Indexer\QueueSubscriber</parameter>
-
-		<parameter key="integrated_solr.indexer.serializer.class">Symfony\Component\Serializer\Serializer</parameter>
-		<parameter key="integrated_solr.indexer.serializer.normalizer.mongodb.class">Integrated\MongoDB\Serializer\Normalizer\ContainerAwareDocumentNormalizer</parameter>
-		<parameter key="integrated_solr.indexer.serializer.encoder.json.class">Symfony\Component\Serializer\Encoder\JsonEncoder</parameter>
-
-		<parameter key="integrated_solr.indexer.class">Integrated\Common\Solr\Indexer\Indexer</parameter>
-
-    </parameters>
-
     <services>
 
-		<service id="integrated_solr.indexer.mongodb.subscriber" class="%integrated_solr.indexer.mongodb.subscriber.class%">
+        <service id="integrated_solr.indexer.error.subscriber" class="Integrated\Bundle\SolrBundle\EventListener\ErrorLogger">
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="null"/>
+            </call>
+
+            <tag name="monolog.logger" channel="solr" />
+            <tag name="integrated_solr.event_subscriber" />
+        </service>
+
+		<service id="integrated_solr.indexer.mongodb.subscriber" class="Integrated\MongoDB\Solr\Indexer\QueueSubscriber">
 			<argument type="service" id="integrated_queue.solr_indexer" /> <!-- should be a config option -->
 			<argument type="service" id="integrated_solr.indexer.serializer" />
 
 			<tag name="doctrine_mongodb.odm.event_subscriber" connection="default" />
 		</service>
 
-		<service id="integrated_solr.indexer.serializer" class="%integrated_solr.indexer.serializer.class%">
+		<service id="integrated_solr.indexer.serializer" class="Symfony\Component\Serializer\Serializer">
 			<argument type="collection">
 				<argument type="service" id="integrated_solr.indexer.serializer.normalizer.mongodb" /> <!-- normalizers should be taggable -->
 			</argument>
@@ -34,25 +31,29 @@
 			</argument>
 		</service>
 
-		<service id="integrated_solr.indexer.serializer.normalizer.mongodb" class="%integrated_solr.indexer.serializer.normalizer.mongodb.class%" public="false">
+		<service id="integrated_solr.indexer.serializer.normalizer.mongodb" class="Integrated\MongoDB\Serializer\Normalizer\ContainerAwareDocumentNormalizer" public="false">
 			<argument type="service" id="service_container"/>
 			<argument type="string">doctrine.odm.mongodb.document_manager</argument> <!-- should be a config option -->
 		</service>
 
-		<service id="integrated_solr.indexer.serializer.encoder.json" class="%integrated_solr.indexer.serializer.encoder.json.class%" public="false" />
+		<service id="integrated_solr.indexer.serializer.encoder.json" class="Symfony\Component\Serializer\Encoder\JsonEncoder" public="false" />
+
+        <service id="integrated_solr.indexer.command_factory" class="Integrated\Common\Solr\Indexer\CommandFactory">
+            <argument type="service" id="integrated_solr.converter" />
+            <argument type="service" id="integrated_solr.indexer.serializer" />
+        </service>
 
 		<service id="integrated_solr.indexer.client" alias="integrated_solr.solarium.client.indexer" />
 
-		<service id="integrated_solr.indexer" class="%integrated_solr.indexer.class%">
+		<service id="integrated_solr.indexer" class="Integrated\Common\Solr\Indexer\Indexer">
+            <argument type="service" id="integrated_solr.indexer.command_factory" />
+
 			<call method="setQueue">
 				<argument type="service" id="integrated_queue.solr_indexer" />
 			</call>
-			<call method="setSerializer">
-				<argument type="service" id="integrated_solr.indexer.serializer" />
-			</call>
-			<call method="setConverter">
-				<argument type="service" id="integrated_solr.converter" />
-			</call>
+            <call method="setEventDispatcher">
+                <argument type="service" id="integrated_solr.event.dispatcher" />
+            </call>
 			<call method="setClient">
 				<argument type="service" id="integrated_solr.solarium.client.indexer" />
 			</call>

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.4",
         "symfony/symfony": "~2.4",
         "symfony/filesystem": "~2.6",
-        "integrated/library": "~0.3"
+        "integrated/library": "~0.5"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "2.*",


### PR DESCRIPTION
Errors while converting document will no longer halt the indexer.
- Console will output error in case of a full or daemon indexer run.
- Update the bundle to work with the latest (0.5) library version.
- Indexing error are now catched and logged in de channel solr.
